### PR TITLE
Integrate lovable.dev for project previews

### DIFF
--- a/FieldOpsSuite_v1/public/lovable-preview.html
+++ b/FieldOpsSuite_v1/public/lovable-preview.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lovable Project Preview</title>
+    <style>
+      :root { color-scheme: light dark; }
+      html, body { height: 100%; margin: 0; }
+      body { display: flex; flex-direction: column; }
+      header { padding: 10px 12px; display:flex; align-items:center; gap: 8px; border-bottom: 1px solid #8884; }
+      header input { flex: 1; padding: 8px 10px; border-radius: 8px; border: 1px solid #8884; background: transparent; color: inherit; }
+      header a.button, header button { padding: 8px 12px; border-radius: 8px; border: 1px solid #8884; background: transparent; color: inherit; text-decoration: none; cursor: pointer; }
+      header a.button:hover, header button:hover { background: #8882; }
+      #frame { flex: 1; width: 100%; border: 0; }
+      .muted { color: #888; font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <strong>Lovable Preview</strong>
+      <input id="url" placeholder="https://lovable.dev/your-project/preview" />
+      <button id="loadBtn">Load</button>
+      <a class="button" href="repos.html">Back</a>
+    </header>
+    <iframe id="frame" allow="clipboard-write; clipboard-read; autoplay; fullscreen" referrerpolicy="no-referrer"></iframe>
+    <script>
+      function getParam(name) {
+        const u = new URL(window.location.href);
+        return u.searchParams.get(name);
+      }
+      function setParam(name, value) {
+        const u = new URL(window.location.href);
+        if (value) u.searchParams.set(name, value); else u.searchParams.delete(name);
+        history.replaceState(null, '', u.toString());
+      }
+      function load() {
+        const urlEl = document.getElementById('url');
+        const frame = document.getElementById('frame');
+        const raw = (urlEl.value || '').trim();
+        if (!raw) return;
+        try {
+          const u = new URL(raw);
+          // Basic allowlist: only load http(s)
+          if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error('Invalid protocol');
+          frame.src = u.toString();
+          setParam('url', u.toString());
+        } catch (e) {
+          alert('Invalid URL');
+        }
+      }
+      document.getElementById('loadBtn').addEventListener('click', load);
+      document.getElementById('url').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') load();
+      });
+      const initial = getParam('url');
+      if (initial) {
+        document.getElementById('url').value = initial;
+        document.getElementById('frame').src = initial;
+      }
+    </script>
+  </body>
+  </html>
+

--- a/FieldOpsSuite_v1/public/lovable.json
+++ b/FieldOpsSuite_v1/public/lovable.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Sample Lovable Project",
+    "projectUrl": "https://lovable.dev/your-org/sample",
+    "previewUrl": "https://lovable.dev/your-org/sample/preview"
+  }
+]
+

--- a/FieldOpsSuite_v1/public/repos.html
+++ b/FieldOpsSuite_v1/public/repos.html
@@ -53,7 +53,7 @@
             row.className = 'repo';
 
             const left = document.createElement('div');
-            left.innerHTML = `<div><strong>${repo.name}</strong></div><div class="meta">${repo.path}${repo.remote ? ' · ' + repo.remote : ''}</div>`;
+            left.innerHTML = `<div><strong>${repo.name}</strong></div><div class="meta">${repo.path || ''}${repo.remote ? (repo.path ? ' · ' : '') + repo.remote : ''}</div>`;
 
             const actions = document.createElement('div');
             actions.className = 'actions';
@@ -67,17 +67,29 @@
               actions.appendChild(openRemote);
             }
 
-            const openLocal = document.createElement('a');
-            openLocal.className = 'button';
-            openLocal.href = `vscode://file/${encodeURIComponent(repo.path)}`;
-            openLocal.textContent = 'Open in Editor';
-            actions.appendChild(openLocal);
+            if (repo.path) {
+              const openLocal = document.createElement('a');
+              openLocal.className = 'button';
+              openLocal.href = `vscode://file/${encodeURIComponent(repo.path)}`;
+              openLocal.textContent = 'Open in Editor';
+              actions.appendChild(openLocal);
 
-            const browseFs = document.createElement('a');
-            browseFs.className = 'button';
-            browseFs.href = repo.path.startsWith('/') ? `file://${repo.path}` : repo.path;
-            browseFs.textContent = 'Browse Files';
-            actions.appendChild(browseFs);
+              const browseFs = document.createElement('a');
+              browseFs.className = 'button';
+              browseFs.href = repo.path.startsWith('/') ? `file://${repo.path}` : repo.path;
+              browseFs.textContent = 'Browse Files';
+              actions.appendChild(browseFs);
+            }
+
+            // Lovable preview support
+            if (repo.provider === 'Lovable' && repo.previewUrl) {
+              const previewBtn = document.createElement('a');
+              previewBtn.className = 'button';
+              previewBtn.href = `lovable-preview.html?url=${encodeURIComponent(repo.previewUrl)}`;
+              previewBtn.textContent = 'Preview';
+              previewBtn.target = '_blank';
+              actions.appendChild(previewBtn);
+            }
 
             row.appendChild(left);
             row.appendChild(actions);


### PR DESCRIPTION
Add integration for lovable.dev projects, allowing them to be listed and previewed within the application.

Cross-origin headers (COOP/COEP) are exempted for the `/lovable-preview` route to enable embedding external lovable.dev project previews in an iframe.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c0313f4-b51b-4e73-8942-789d329e9414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c0313f4-b51b-4e73-8942-789d329e9414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

